### PR TITLE
Fix expo-camera plugin project gradle path

### DIFF
--- a/apps/expo/app.json
+++ b/apps/expo/app.json
@@ -30,6 +30,7 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": ["./plugins/withCameraMonorepo"]
   }
 }

--- a/apps/expo/plugins/withCameraMonorepo.js
+++ b/apps/expo/plugins/withCameraMonorepo.js
@@ -6,7 +6,7 @@ const {
 // See: https://github.com/expo/expo/blob/6877c1f5cdca62b395b0d5f49d87f2f3dbb50bec/packages/expo-camera/plugin/src/withCamera.ts#L18
 const wrongPath = `url "$rootDir/../node_modules/expo-camera/android/maven"`;
 // See: https://github.com/expo/expo/blob/b574deb5b399b05bbd16a1fd9d6232e6d58c27e8/packages/expo-camera/plugin/src/withCamera.ts#L23
-const rightPath = `url new File(["node", "--print", "require.resolve('expo-camera/package.json')"].execute(null, rootDir).text.trim(), "../android/maven")`;
+const rightPath = `url(new File(["node", "--print", "require.resolve('expo-camera/package.json')"].execute(null, rootDir).text.trim(), "../android/maven"))`;
 
 function withCameraMonorepo(config) {
   return withProjectBuildGradle(config, (config) => {

--- a/apps/expo/plugins/withCameraMonorepo.js
+++ b/apps/expo/plugins/withCameraMonorepo.js
@@ -1,0 +1,25 @@
+const {
+  withProjectBuildGradle,
+  createRunOncePlugin,
+} = require('@expo/config-plugins');
+
+// See: https://github.com/expo/expo/blob/6877c1f5cdca62b395b0d5f49d87f2f3dbb50bec/packages/expo-camera/plugin/src/withCamera.ts#L18
+const wrongPath = `url "$rootDir/../node_modules/expo-camera/android/maven"`;
+// See: https://github.com/expo/expo/blob/b574deb5b399b05bbd16a1fd9d6232e6d58c27e8/packages/expo-camera/plugin/src/withCamera.ts#L23
+const rightPath = `url new File(["node", "--print", "require.resolve('expo-camera/package.json')"].execute(null, rootDir).text.trim(), "../android/maven")`;
+
+function withCameraMonorepo(config) {
+  return withProjectBuildGradle(config, (config) => {
+    if (config.modResults.language === 'groovy') {
+      // Try to patch the hardcoded non-monorepo path with dynamic imports, to make it work with monorepos
+      config.modResults.contents = config.modResults.contents.replace(wrongPath, rightPath);
+    } else {
+      throw new Error('Cannot fix camera maven gradle because the build.gradle is not groovy');
+    }
+
+    return config;
+  });
+}
+
+// This package doesn't exists, but it helps keeping track if this was executed already
+module.exports = createRunOncePlugin(withCameraMonorepo, 'expo-camera-monorepo-fix', '1.0.0');


### PR DESCRIPTION
Hi Ty! 

I found the issue inside one of our plugins, namely the `expo-camera` plugin. It's causing the issue by hardcoding the path. This plugin replaces that wrong path with a correct one, which is compatible with monorepos. I added the comments if you want to look it up, feel free to remove them.

I will also open a bug report and a patch, hopefully, we can ship it out soon and you can delete the plugin. For now, this should work!